### PR TITLE
Fix Cirrus CI failure : /lib/libthr.so.3: version FBSD_1.6 not found.

### DIFF
--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -29,7 +29,11 @@ freebsd_install() {
     python
     ruby25
 "
+  uname -a
+  pkg-static -v
+
   # Note: we assume sudo is already installed
+  sudo pkg-static upgrade pkg
   sudo pkg install -y ${packages}
 
   cd /usr/ports/devel/ruby-gems


### PR DESCRIPTION
Fixes Cirrus CI failure:
ld-elf.so.1: /lib/libthr.so.3: version FBSD_1.6 required by /usr/local/lib/libruby25.so.25 not found